### PR TITLE
add a built-in copy helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
 export { compose } from './source/compose.js'
+export { copy } from './source/copy.js'
 export { lens } from './source/lens.js'

--- a/source/copy.js
+++ b/source/copy.js
@@ -1,0 +1,21 @@
+const copy = (data, keys) => {
+  if (keys.length === 0) return data
+
+  const key = keys.shift()
+
+  if (Array.isArray(data)) {
+    return data.map((item, i) => i == key ? copy(item, keys.slice()) : item)
+  }
+
+  if (data && typeof data === 'object') {
+    const target = {}
+    for (const k in data) {
+      target[k] = k === key ? copy(data[k], keys.slice()) : data[k]
+    }
+    return target
+  }
+
+  return data
+}
+
+export { copy }

--- a/source/lens.js
+++ b/source/lens.js
@@ -55,7 +55,7 @@ const lens = ([...args], copy = noop) => {
     if (! value_provided) {
       return get(structure)
     } else {
-      return set(copy(structure), value)
+      return set(copy(structure, args.slice()), value)
     }
   }
   return fn

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,5 @@
 import { test } from 'tape'
-import { lens } from '../'
-import { compose } from '../source/compose'
+import { lens, compose, copy } from '../'
 
 test('exports a function', t => {
   t.equal(typeof lens, 'function')
@@ -253,5 +252,22 @@ test('applies copy function to complex types', t => {
   t.equal(typeof data.modified, 'undefined')
   t.equal(modified(result), true)
   t.equal(typeof data, typeof result)
+  t.end()
+})
+
+test('uses structural sharing when using provided copy function', t => {
+  const data = {
+    a: { b: { c: 1 }, d: {} },
+    e: { f: {} }
+  };
+  const c = lens(['a', 'b', 'c'], copy)
+  const before = JSON.stringify(data)
+  const result = c(data, 2)
+  const after = JSON.stringify(result)
+  t.notEqual(before, after)
+  t.equal(data.a.b.c, 1);
+  t.equal(result.a.b.c, 2);
+  t.equal(result.e, data.e)
+  t.equal(result.a.d, data.a.d)
   t.end()
 })


### PR DESCRIPTION
This adds a built-in `copy` function that can be used to clone the data a lens is being applied to using structural sharing. It avoids the performance overhead of the `JSON` hack, while bypassing the limitations around cyclical structures and JSON-supported data types, and is simpler and more performant than solutions like `_.cloneDeep` (which need to keep track in memory of which values have already been seen, to avoid a stack overflow).

Since subtrees are shared between the before and after, this is also kinder on the heap, if you're hanging on to old values for (e.g.) an undo stack.

Question: should it handle other types like `Set` and `Map`? Or should that be solved in userland?